### PR TITLE
update implementation of delete modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css';
-import { ChangeEvent, useRef, useState } from 'react';
+import { ChangeEvent, RefObject, useState } from 'react';
 import TaskListContainer from './components/TaskListContainer/TaskListContainer';
 import DeleteModalContainer from './components/DeleteModalContainer';
 import AddTaskContainer from './components/AddTaskContainer/AddTaskContainer';
@@ -8,6 +8,7 @@ import { useTaskManager } from './hooks/useTaskManager';
 
 function App() {
   const [searchInput, setSearchInput] = useState<string>(''); //tracks search input
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const {
     tasks,
@@ -17,10 +18,19 @@ function App() {
     deleteSingleTaskHandler,
   } = useTaskManager();
 
-  const deleteModalRef = useRef<HTMLDialogElement>(null);
-
   const openDeleteModal = () => {
-    deleteModalRef.current?.showModal();
+    setIsModalOpen(true);
+  };
+  const closeDeleteModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleModal = (modalRef: RefObject<HTMLDialogElement>) => {
+    if (isModalOpen === true) {
+      modalRef.current?.showModal();
+    } else {
+      modalRef.current?.close();
+    }
   };
 
   //Handle search input
@@ -41,7 +51,8 @@ function App() {
   return (
     <main>
       <DeleteModalContainer
-        deleteModalRef={deleteModalRef}
+        closeDeleteModal={closeDeleteModal}
+        handleModal={handleModal}
         deleteAll={deleteAllTasksHandler}
         tasks={tasks}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { useTaskManager } from './hooks/useTaskManager';
 
 function App() {
   const [searchInput, setSearchInput] = useState<string>(''); //tracks search input
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const {
     tasks,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css';
-import { ChangeEvent, RefObject, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import TaskListContainer from './components/TaskListContainer/TaskListContainer';
 import DeleteModalContainer from './components/DeleteModalContainer';
 import AddTaskContainer from './components/AddTaskContainer/AddTaskContainer';
@@ -25,14 +25,6 @@ function App() {
     setIsModalOpen(false);
   };
 
-  const handleModal = (modalRef: RefObject<HTMLDialogElement>) => {
-    if (isModalOpen === true) {
-      modalRef.current?.showModal();
-    } else {
-      modalRef.current?.close();
-    }
-  };
-
   //Handle search input
   const handleSearchInput = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);
@@ -51,8 +43,8 @@ function App() {
   return (
     <main>
       <DeleteModalContainer
+        isModalOpen={isModalOpen}
         closeDeleteModal={closeDeleteModal}
-        handleModal={handleModal}
         deleteAll={deleteAllTasksHandler}
         tasks={tasks}
       />

--- a/src/components/DeleteModalContainer.tsx
+++ b/src/components/DeleteModalContainer.tsx
@@ -1,27 +1,28 @@
-import { RefObject } from 'react';
+import { RefObject, useRef } from 'react';
 import { Task } from '../utils/types';
 import DeleteModalUI from './DeleteModalUI';
 
 interface DeleteModalContainerProps {
-  deleteModalRef: RefObject<HTMLDialogElement>;
+  handleModal: (modalRef: RefObject<HTMLDialogElement>) => void;
+  closeDeleteModal: () => void;
   tasks: Task[];
   deleteAll: () => Promise<void>;
 }
 
 function DeleteModalContainer({
-  deleteModalRef,
+  handleModal,
+  closeDeleteModal,
   tasks,
   deleteAll,
 }: DeleteModalContainerProps) {
+  const deleteModalRef = useRef<HTMLDialogElement>(null);
+
+  handleModal(deleteModalRef);
+
   //Handle deleting all tasks
   const handleTasksDelete = async () => {
     await deleteAll();
-    deleteModalRef.current?.close();
-  };
-
-  //Handle closing the modal when it's open
-  const handleCloseModal = () => {
-    deleteModalRef.current?.close();
+    closeDeleteModal();
   };
 
   //Boolean to conditionally render options in modal
@@ -34,7 +35,7 @@ function DeleteModalContainer({
     >
       <DeleteModalUI
         handleDeleteAll={handleTasksDelete}
-        handleCloseModal={handleCloseModal}
+        handleCloseModal={closeDeleteModal}
         hasTasks={hasTasks}
       />
     </dialog>

--- a/src/components/DeleteModalContainer.tsx
+++ b/src/components/DeleteModalContainer.tsx
@@ -1,23 +1,29 @@
-import { RefObject, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Task } from '../utils/types';
 import DeleteModalUI from './DeleteModalUI';
 
 interface DeleteModalContainerProps {
-  handleModal: (modalRef: RefObject<HTMLDialogElement>) => void;
+  isModalOpen: boolean;
   closeDeleteModal: () => void;
   tasks: Task[];
   deleteAll: () => Promise<void>;
 }
 
 function DeleteModalContainer({
-  handleModal,
+  isModalOpen,
   closeDeleteModal,
   tasks,
   deleteAll,
 }: DeleteModalContainerProps) {
   const deleteModalRef = useRef<HTMLDialogElement>(null);
 
-  handleModal(deleteModalRef);
+  useEffect(() => {
+    if (isModalOpen) {
+      deleteModalRef.current?.showModal();
+    } else {
+      deleteModalRef.current?.close();
+    }
+  }, [isModalOpen]);
 
   //Handle deleting all tasks
   const handleTasksDelete = async () => {


### PR DESCRIPTION
## Description
This PR removes the passing of refs as props for the implementation of the `DeleteModalContainer` component by using `useState`.

## Changes Made
- defined a ref within the modal component
- created open and close functions within `App` component to change open/close state
- created `handleModal` function that is passed as props to modal component